### PR TITLE
feat: LANZ-2154 add action to process cfn json conf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 
 Repository containing Ohpen's Github actions. An easy-to-setup set of scripts and actions to help teams (and everybody that needs it) start working with their repositories and abstract as much cognitive load from them.
 
-- [code-of-conduct](#code-of-conduct)
-- [git-actions](#git)
-  - [semver-and-changelog](#semver-and-changelog)
-  - [check-conventional-commits](#check-conventional-commits)
-  - [check-jira-tickets-commits](#check-jira-tickets-commits)
-- [terraform-actions](#terraform)
-  - [validate](#validate)
-  - [plan](#plan)
-  - [apply](#apply)
-- [post-deployment-actions](#post-deployment)
-  - [update-deployment-info](#update-deployment-info)
-- [build-actions](#build-actions)
-  - [dotnet](#dotnet)
-    - [build-dotnet-app](#build-dotnet-app)
-  - [java](#java)
-    - [setup-maven](#setup-maven)
-    - [run-maven](#run-maven)
+- [PLATFORM-CICD](#platform-cicd)
+  - [code-of-conduct](#code-of-conduct)
+  - [git](#git)
+    - [semver-and-changelog](#semver-and-changelog)
+    - [check-conventional-commits](#check-conventional-commits)
+    - [check-jira-tickets-commits](#check-jira-tickets-commits)
+  - [terraform](#terraform)
+    - [validate](#validate)
+    - [plan](#plan)
+    - [apply](#apply)
+  - [cloudformation](#cloudformation)
+    - [get-properties-from-json](#get-properties-from-json)
+  - [post-deployment](#post-deployment)
+    - [update-deployment-info](#update-deployment-info)
+  - [build-actions](#build-actions)
+    - [dotnet](#dotnet)
+      - [build-dotnet-app](#build-dotnet-app)
+    - [java](#java)
+      - [setup-maven](#setup-maven)
+      - [run-maven](#run-maven)
 
 ## code-of-conduct
 
@@ -259,6 +262,75 @@ jobs:
           terraform-outputs-file: "deployment-team-branch-outputs/outputs.json"
 ```
 
+## cloudformation
+
+### get-properties-from-json
+
+This actions will parse input json file based on input parameter *json-file-path* and search for element matching input parameter *account-name* and exposes following outputs:
+
+- environment
+- account_id
+- account_name
+- cfn_main_file
+- stack_name
+- capabilities
+
+expected json file format is following:
+
+```json
+{
+    "cfn_main_file": "main.yaml",
+    "stack_name": "awesome_stack",
+    "capabilities": "CAPABILITY_AUTO_EXPAND,CAPABILITY_NAMED_IAM",
+    "accounts": [
+        {
+            "environment": "acc",
+            "account_name": "client-acc",
+            "account_id": "012345678900"
+        },
+        {
+            "environment": "acc",
+            "account_name": "internal-acc",
+            "account_id": "012345678901"
+        },
+        {
+            "environment": "acc",
+            "account_name": "external-acc",
+            "account_id": "012345678902"
+        }
+    ]
+}
+```
+
+example usage:
+
+```yaml
+name: CI
+on:
+  pull_request:
+    branches: ["main"]
+jobs:
+    build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Properties From Json
+        id: get-properties
+        uses: ohpensource/platform-cicd/actions/aws/cloudformation/get-properties-from-json@2.15.0.x
+        with:
+          account-name: "account-name-you-need"
+          json-file-path: ./params/matrix.json
+      - name: output usage
+        run: |
+          echo ${{steps.get-properties.outputs.account_id}}
+          echo ${{steps.get-properties.outputs.account_name}}
+          echo ${{steps.get-properties.outputs.environment}}
+          echo ${{steps.get-properties.outputs.cfn_main_file}}
+          echo ${{steps.get-properties.outputs.stack_name}}
+          echo ${{steps.get-properties.outputs.capabilities}}
+```
+
+
 ## post-deployment
 
 ### update-deployment-info
@@ -291,6 +363,7 @@ jobs:
         with:
           app-path: "src"
 ```
+
 
 ### java
 

--- a/actions/aws/cloudformation/get-properties-from-json/action.yml
+++ b/actions/aws/cloudformation/get-properties-from-json/action.yml
@@ -1,0 +1,68 @@
+name: "get-properties-from-json"
+description: "get and set properties from ohpen cfn json conf files"
+inputs:
+  account-name:
+    description: "aws account name"
+    required: true
+  json-file-path:
+    description: "path to json file"
+    required: true
+outputs:
+  environment:
+    description: "environment value from account json element"
+    value: ${{ steps.get-properties.outputs.environment }}
+  account_id:
+    description: "account id value from account json element"
+    value: ${{ steps.get-properties.outputs.account_id }}
+  account_name:
+    description: "account name value from account json element"
+    value: ${{ steps.get-properties.outputs.account_name }}
+  cfn_main_file:
+    description: "cfn_main_file value from main json element"
+    value: ${{ steps.get-properties.outputs.cfn_main_file }}
+  stack_name:
+    description: "stack_name value from main json element"
+    value: ${{ steps.get-properties.outputs.stack_name }}
+  capabilities:
+    description: "stack_name value from main json element"
+    value: ${{ steps.get-properties.outputs.capabilities }}
+runs:
+  using: "composite"
+  steps:
+    - id: get-properties
+      shell: bash    
+      run: |
+        ACCOUNT=${{ inputs.account-name }}
+        JSONPATH=${{ inputs.json-file-path }}
+        echo $ACCOUNT
+          
+        cfn_main_file=$(jq '.cfn_main_file' ./$JSONPATH | tr '\"' ' ' | xargs)
+        stack_name=$(jq '.stack_name' ./$JSONPATH | tr '\"' ' ' | xargs)
+        capabilities=$(jq '.capabilities' ./$JSONPATH | tr '\"' ' ' | xargs)
+
+        environment=""
+        account_name=""
+        account_id=""
+
+        jq -c '.accounts[]' ./$JSONPATH | while read i; do
+
+          account_name=$(echo $i | jq '.account_name' | tr '\"' ' ' | xargs)
+
+          if [ $ACCOUNT = $account_name ]
+          then
+              environment=$(echo $i | jq '.environment' | tr '\"' ' ' | xargs)
+              account_name=$(echo $i | jq '.account_name' | tr '\"' ' ' | xargs)
+              account_id=$(echo $i | jq '.account_id' | tr '\"' ' ' | xargs)
+              echo "FINAL"
+              echo "ENV: " $environment 
+              echo "ACCOUNT NAME: " $account_name 
+              echo "ACCOUNT_ID: " $account_id      
+              echo "::set-output name=environment::$environment"
+              echo "::set-output name=account_name::$account_name"
+              echo "::set-output name=account_id::$account_id"
+          fi
+        done
+
+        echo "::set-output name=cfn_main_file::$cfn_main_file"
+        echo "::set-output name=stack_name::$stack_name"
+        echo "::set-output name=capabilities::$capabilities"


### PR DESCRIPTION
while implementing ng-base deployment from GitHub I got to the point where I need to process file like this:
{
    "cfn_main_file": "ng-base-main.yaml",
    "stack_name": "ng-base",
    "capabilities": "CAPABILITY_AUTO_EXPAND,CAPABILITY_NAMED_IAM",
    "accounts": [
        {
            "environment": "dev",
            "account_name": "dev-infra",
            "account_id": "061211638568"
        },
        {
            "environment": "dev",
            "account_name": "dev-core",
            "account_id": "935175866078"
        },
        {
            "environment": "dev",
            "account_name": "dev-classic",
            "account_id": "419040100698"
        },
        {
            "environment": "dev",
            "account_name": "dev-investments",
            "account_id": "500488349432"
        }
    ]
    
}

This action do filter based on 2 inputs - path to json file and account-name I need to get properties from and expose:
- environment
- account_name
- account_id
- cfn_main_file
- stack_name
- capabilities